### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
         run: mvn --batch-mode -Pdefault,coverage install
 
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: farao/gridcapa-core-cc
           tags: ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore