### PR TITLE
Temp dir

### DIFF
--- a/gridcapa-core-cc-app/src/main/java/com/farao_community/farao/gridcapa_core_cc/app/services/FileImporter.java
+++ b/gridcapa-core-cc-app/src/main/java/com/farao_community/farao/gridcapa_core_cc/app/services/FileImporter.java
@@ -124,13 +124,13 @@ public class FileImporter {
         }
     }
 
-// TODO :  gridcapa-core-cc-temp-dir ?
     public CgmsAndXmlHeader importCgmsZip(CoreCCFileResource cgmsZimFileResource) {
         try (InputStream cgmsZipInputStream = urlValidationService.openUrlStream(cgmsZimFileResource.getUrl())) {
             LOGGER.info("Import of cgms zip from {} file ", cgmsZimFileResource.getFilename());
 
             FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
-            Path tmpCgmInputsPath = Files.createDirectories(Paths.get("/tmp/gridcapa-core-cc-temp-dir" + File.separator + "cgm"), attr);
+            String tempDir = System.getProperty("java.io.tmpdir");
+            Path tmpCgmInputsPath = Files.createDirectories(Paths.get(tempDir + "/gridcapa-core-cc-temp-dir" + File.separator + "cgm"), attr);
             List<Path> unzippedPaths = ZipUtil.unzipInputStream(cgmsZipInputStream, tmpCgmInputsPath);
             Path xmlHeaderPath = unzippedPaths.stream().filter(p -> p.toFile().getName().matches(NamingRules.CGM_XML_HEADER_NAME))
                 .findFirst().orElseThrow(() -> new CoreCCInvalidDataException("CGM zip does not contain XML header"));

--- a/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/MinioFileWriter.java
+++ b/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/MinioFileWriter.java
@@ -22,15 +22,17 @@ import java.time.OffsetDateTime;
  */
 public class MinioFileWriter extends MinioAdapter {
 
+    private final static String tempDir = System.getProperty("java.io.tmpdir");
+
     public MinioFileWriter(MinioAdapterProperties properties, MinioClient minioClient) {
         super(properties, minioClient);
     }
 
     @Override
     public void uploadOutput(String path, InputStream inputStream) {
-        File tmpDir = new File("/tmp/outputs/");
-        if (!tmpDir.exists()) {
-            boolean created = tmpDir.mkdir();
+        File outputDir = new File(tempDir + "/outputs/");
+        if (!outputDir.exists()) {
+            boolean created = outputDir.mkdir();
         }
         File targetFile = new File(path);
         try {
@@ -42,13 +44,13 @@ public class MinioFileWriter extends MinioAdapter {
 
     @Override
     public void uploadOutputForTimestamp(String path, InputStream inputStream, @Nullable String targetProcess, @Nullable String type, OffsetDateTime timestamp) {
-        String tmpDirPath = "/tmp/gridcapa-core-cc/";
+        String outputDir = tempDir + "/gridcapa-core-cc/";
         String additionalPathName = targetProcess + "/" + type + "/" + timestamp + "/" + timestamp.plusHours(1L) + "/";
-        File tmpDir = new File(tmpDirPath + additionalPathName);
+        File tmpDir = new File(outputDir + additionalPathName);
         if (!tmpDir.exists()) {
             boolean created = tmpDir.mkdir();
         }
-        String fullPath = tmpDirPath + additionalPathName + path;
+        String fullPath = outputDir + additionalPathName + path;
         File targetFile = new File(fullPath);
         try {
             FileUtils.copyInputStreamToFile(inputStream, targetFile);

--- a/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/MinioFileWriter.java
+++ b/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/MinioFileWriter.java
@@ -22,7 +22,7 @@ import java.time.OffsetDateTime;
  */
 public class MinioFileWriter extends MinioAdapter {
 
-    private final static String tempDir = System.getProperty("java.io.tmpdir");
+    private final String tempDir = System.getProperty("java.io.tmpdir");
 
     public MinioFileWriter(MinioAdapterProperties properties, MinioClient minioClient) {
         super(properties, minioClient);

--- a/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/postprocessing/FileExporterHelperTest.java
+++ b/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/postprocessing/FileExporterHelperTest.java
@@ -63,7 +63,7 @@ class FileExporterHelperTest {
     private final MinioAdapterProperties properties = Mockito.mock(MinioAdapterProperties.class);
     private final MinioClient minioClient = Mockito.mock(MinioClient.class);
     private final MinioFileWriter minioFileWriter = new MinioFileWriter(properties, minioClient);
-    private static final String tempDir = System.getProperty("java.io.tmpdir");
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
 
     @BeforeEach
     void setUp() {
@@ -90,7 +90,7 @@ class FileExporterHelperTest {
     void exportNetworkToMinio() throws IOException {
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportNetworkToMinio(coreCCRequest);
-        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/CGM_OUT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_2D2_UX1.uct";
+        String generatedFilePath = TEMP_DIR + "/gridcapa-core-cc/CORE_CC/CGM_OUT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_2D2_UX1.uct";
         removeCreationDateFromUct(new File(generatedFilePath));
         assertFilesContentEqual("/fileExporterHelper/uploadedNetwork.uct", generatedFilePath);
 
@@ -114,7 +114,7 @@ class FileExporterHelperTest {
     void exportRaoResultToMinio() throws IOException {
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportRaoResultToMinio(coreCCRequest);
-        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/RAO_RESULT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/raoResult.json";
+        String generatedFilePath = TEMP_DIR + "/gridcapa-core-cc/CORE_CC/RAO_RESULT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/raoResult.json";
         assertFilesContentEqual("/fileExporterHelper/uploadedRaoResult.json", generatedFilePath);
     }
 
@@ -141,7 +141,7 @@ class FileExporterHelperTest {
         Mockito.when(hourlyRaoResult.getErrorMessage()).thenReturn("Error message.");
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportMetadataToMinio(coreCCRequest);
-        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/METADATA/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1830_METADATA-01.json";
+        String generatedFilePath = TEMP_DIR + "/gridcapa-core-cc/CORE_CC/METADATA/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1830_METADATA-01.json";
         assertFilesContentEqual("/fileExporterHelper/uploadedMetadata.json", generatedFilePath);
     }
 
@@ -184,7 +184,7 @@ class FileExporterHelperTest {
 
         fileExporterHelper.exportCneToMinio(coreCCRequest);
 
-        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/CNE/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_20230725-F299-v1-22XCORESO------S_to_17XTSO-CS------W.xml";
+        String generatedFilePath = TEMP_DIR + "/gridcapa-core-cc/CORE_CC/CNE/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_20230725-F299-v1-22XCORESO------S_to_17XTSO-CS------W.xml";
         removeCreationDateInCne(new File(generatedFilePath));
         assertFilesContentEqual("/fileExporterHelper/uploadedCne.xml", generatedFilePath);
 
@@ -245,7 +245,7 @@ class FileExporterHelperTest {
 
     @AfterAll
     public static void deleteTemporaryDirectory() throws IOException {
-        FileUtils.deleteDirectory(new File(tempDir + "/gridcapa-core-cc"));
+        FileUtils.deleteDirectory(new File(TEMP_DIR + "/gridcapa-core-cc"));
     }
 
 }

--- a/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/postprocessing/FileExporterHelperTest.java
+++ b/gridcapa-core-cc-app/src/test/java/com/farao_community/farao/gridcapa_core_cc/app/postprocessing/FileExporterHelperTest.java
@@ -63,6 +63,7 @@ class FileExporterHelperTest {
     private final MinioAdapterProperties properties = Mockito.mock(MinioAdapterProperties.class);
     private final MinioClient minioClient = Mockito.mock(MinioClient.class);
     private final MinioFileWriter minioFileWriter = new MinioFileWriter(properties, minioClient);
+    private static final String tempDir = System.getProperty("java.io.tmpdir");
 
     @BeforeEach
     void setUp() {
@@ -89,7 +90,7 @@ class FileExporterHelperTest {
     void exportNetworkToMinio() throws IOException {
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportNetworkToMinio(coreCCRequest);
-        String generatedFilePath = "/tmp/gridcapa-core-cc/CORE_CC/CGM_OUT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_2D2_UX1.uct";
+        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/CGM_OUT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_2D2_UX1.uct";
         removeCreationDateFromUct(new File(generatedFilePath));
         assertFilesContentEqual("/fileExporterHelper/uploadedNetwork.uct", generatedFilePath);
 
@@ -113,7 +114,7 @@ class FileExporterHelperTest {
     void exportRaoResultToMinio() throws IOException {
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportRaoResultToMinio(coreCCRequest);
-        String generatedFilePath = "/tmp/gridcapa-core-cc/CORE_CC/RAO_RESULT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/raoResult.json";
+        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/RAO_RESULT/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/raoResult.json";
         assertFilesContentEqual("/fileExporterHelper/uploadedRaoResult.json", generatedFilePath);
     }
 
@@ -140,7 +141,7 @@ class FileExporterHelperTest {
         Mockito.when(hourlyRaoResult.getErrorMessage()).thenReturn("Error message.");
         FileExporterHelper fileExporterHelper = new FileExporterHelper(minioFileWriter, fileImporter);
         fileExporterHelper.exportMetadataToMinio(coreCCRequest);
-        String generatedFilePath = "/tmp/gridcapa-core-cc/CORE_CC/METADATA/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1830_METADATA-01.json";
+        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/METADATA/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1830_METADATA-01.json";
         assertFilesContentEqual("/fileExporterHelper/uploadedMetadata.json", generatedFilePath);
     }
 
@@ -183,7 +184,7 @@ class FileExporterHelperTest {
 
         fileExporterHelper.exportCneToMinio(coreCCRequest);
 
-        String generatedFilePath = "/tmp/gridcapa-core-cc/CORE_CC/CNE/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_20230725-F299-v1-22XCORESO------S_to_17XTSO-CS------W.xml";
+        String generatedFilePath = tempDir + "/gridcapa-core-cc/CORE_CC/CNE/2023-07-27T10:47:51+02:00/2023-07-27T11:47:51+02:00/path/20230725_1730_20230725-F299-v1-22XCORESO------S_to_17XTSO-CS------W.xml";
         removeCreationDateInCne(new File(generatedFilePath));
         assertFilesContentEqual("/fileExporterHelper/uploadedCne.xml", generatedFilePath);
 
@@ -244,7 +245,7 @@ class FileExporterHelperTest {
 
     @AfterAll
     public static void deleteTemporaryDirectory() throws IOException {
-        FileUtils.deleteDirectory(new File("/tmp/gridcapa-core-cc"));
+        FileUtils.deleteDirectory(new File(tempDir + "/gridcapa-core-cc"));
     }
 
 }


### PR DESCRIPTION
All occurences of `/tmp` have been replaced by `System.getProperty("java.io.tmpdir")` to adapt the path of the temp dir to the OS on which the code is run.